### PR TITLE
Fix item reference issue and add auction creation on click

### DIFF
--- a/src/main/java/fr/epicanard/globalmarketchest/gui/shops/interfaces/CreateAuctionItem.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/gui/shops/interfaces/CreateAuctionItem.java
@@ -157,15 +157,18 @@ public class CreateAuctionItem extends ShopInterface {
    */
   @Override
   public void onDrop(InventoryClickEvent event, InventoryGUI inv) {
-    ItemStack item;
-    if (event.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY)
+    ItemStack item = null;
+    if (event.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY) {
       item = event.getCurrentItem();
-    else {
+      event.setCancelled(true);
+    } else if (event.getSlot() == 22) {
       item = event.getCursor();
       event.getWhoClicked().setItemOnCursor(null);
-      event.getWhoClicked().getInventory().addItem(item);
+      event.getWhoClicked().getInventory().addItem(item.clone());
+      event.setCancelled(true);
     }
-    this.setItem(item);
+    if (item != null)
+      this.setItem(item);
   }
 
   @Override


### PR DESCRIPTION
- Fix #29 
- Duplication of item that must be readded to inventory to prevent stacking reference issue
- Fix issue where item can be set in view by clicking everywhere inside chest. Now it's available by clicking on middle (slot 22) or by drag and drop