### PR TITLE
Features: Damaged items and Items blacklist

### DIFF
--- a/src/main/java/fr/epicanard/globalmarketchest/gui/shops/interfaces/CreateAuctionItem.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/gui/shops/interfaces/CreateAuctionItem.java
@@ -21,11 +21,15 @@ import fr.epicanard.globalmarketchest.utils.ItemStackUtils;
 import fr.epicanard.globalmarketchest.utils.LangUtils;
 
 public class CreateAuctionItem extends ShopInterface {
+  private Boolean accepteDamagedItems;
+
   public CreateAuctionItem(InventoryGUI inv) {
     super(inv);
     this.isTemp = true;
     this.actions.put(22, i -> this.unsetItem());
     this.actions.put(0, new PreviousInterface());
+
+    this.accepteDamagedItems = GlobalMarketChest.plugin.getConfigLoader().getConfig().getBoolean("Options.AcceptDamagedItems", true);
 
     Boolean max = GlobalMarketChest.plugin.getConfigLoader().getConfig().getBoolean("Options.EnableMaxRepeat", true);
     Boolean one = GlobalMarketChest.plugin.getConfigLoader().getConfig().getBoolean("Options.EnableMaxInOne", true);
@@ -78,6 +82,7 @@ public class CreateAuctionItem extends ShopInterface {
    * Remove the item from drop zone
    */
   private void unsetItem() {
+    this.inv.getWarn().stopWarn();
     this.inv.getTransaction().remove(TransactionKey.TEMPITEM);
     this.inv.getTransaction().remove(TransactionKey.AUCTIONAMOUNT);
     ItemStack[] items = InterfacesLoader.getInstance().getInterface("CreateAuctionItem");
@@ -122,6 +127,7 @@ public class CreateAuctionItem extends ShopInterface {
    * Put all items matching with droppped item in one auction
    */
   private void defineMaxInOne() {
+    this.inv.getWarn().stopWarn();
     ItemStack item = this.inv.getTransactionValue(TransactionKey.TEMPITEM);
     AuctionInfo auction = this.inv.getTransactionValue(TransactionKey.AUCTIONINFO);
 
@@ -142,6 +148,7 @@ public class CreateAuctionItem extends ShopInterface {
    * The auction number is limited by config
    */
   private void defineMaxRepeat() {
+    this.inv.getWarn().stopWarn();
     final ItemStack item = this.inv.getTransactionValue(TransactionKey.TEMPITEM);
     final AuctionInfo auction = this.inv.getTransactionValue(TransactionKey.AUCTIONINFO);
     if (item == null || auction == null)
@@ -180,8 +187,13 @@ public class CreateAuctionItem extends ShopInterface {
       event.getWhoClicked().getInventory().addItem(item.clone());
       event.setCancelled(true);
     }
-    if (item != null)
-      this.setItem(item);
+    if (item != null) {
+      this.inv.getWarn().stopWarn();
+      if (!this.accepteDamagedItems && ItemStackUtils.isDamaged(item))
+        this.inv.getWarn().warn("DamagedItem", 40);
+      else
+        this.setItem(item);
+    }
   }
 
   @Override

--- a/src/main/java/fr/epicanard/globalmarketchest/gui/shops/interfaces/CreateAuctionItem.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/gui/shops/interfaces/CreateAuctionItem.java
@@ -189,7 +189,9 @@ public class CreateAuctionItem extends ShopInterface {
     }
     if (item != null) {
       this.inv.getWarn().stopWarn();
-      if (!this.accepteDamagedItems && ItemStackUtils.isDamaged(item))
+      if (ItemStackUtils.isBlacklisted(item))
+        this.inv.getWarn().warn("BlacklistedItem", 40);
+      else if (!this.accepteDamagedItems && ItemStackUtils.isDamaged(item))
         this.inv.getWarn().warn("DamagedItem", 40);
       else
         this.setItem(item);

--- a/src/main/java/fr/epicanard/globalmarketchest/utils/ItemStackUtils.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/utils/ItemStackUtils.java
@@ -204,4 +204,15 @@ public class ItemStackUtils {
   public Boolean isDamaged(ItemStack item) {
     return ((Damageable)item.getItemMeta()).getDamage() > 0;
   }
+
+  /**
+   * Define if the block is black listed or not
+   * 
+   * @param item Item to define if blacklisted
+   * @return
+   */
+  public Boolean isBlacklisted(ItemStack item) {
+    String mk = ItemStackUtils.getMinecraftKey(item);
+    return GlobalMarketChest.plugin.getConfigLoader().getConfig().getStringList("ItemsBlacklist").contains(mk);
+  }
 }

--- a/src/main/java/fr/epicanard/globalmarketchest/utils/ItemStackUtils.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/utils/ItemStackUtils.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import fr.epicanard.globalmarketchest.GlobalMarketChest;
@@ -192,5 +193,15 @@ public class ItemStackUtils {
     }
 
     return items.toArray(new ItemStack[0]);
+  }
+
+  /**
+   * Define if the item is damaged
+   * 
+   * @param item ItemStack to define if it is damaged
+   * @return
+   */
+  public Boolean isDamaged(ItemStack item) {
+    return ((Damageable)item.getItemMeta()).getDamage() > 0;
   }
 }

--- a/src/main/java/fr/epicanard/globalmarketchest/utils/WorldUtils.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/utils/WorldUtils.java
@@ -171,7 +171,7 @@ public class WorldUtils {
   public Boolean isAllowedWorld(String worldName) throws WorldDoesntExist {
     if (Bukkit.getWorld(worldName) == null)
       throw new WorldDoesntExist(worldName);
-    return GlobalMarketChest.plugin.getConfigLoader().getConfig().getList("WorldAllowed").contains(worldName);
+    return GlobalMarketChest.plugin.getConfigLoader().getConfig().getStringList("WorldAllowed").contains(worldName);
   }
 
   /**

--- a/src/main/resources/config - 1.12.yml
+++ b/src/main/resources/config - 1.12.yml
@@ -38,7 +38,7 @@ Options:
   # -1 to ignore purge else specific a number of days to purge database every n days
   PurgeInterval: 30
   # Define if the player can create auctions with an item damaged
-  AcceptDamagedItems: true
+  AcceptDamagedItems: false
 WorldAllowed:
   - world
   - world_the_end

--- a/src/main/resources/config - 1.12.yml
+++ b/src/main/resources/config - 1.12.yml
@@ -37,6 +37,8 @@ Options:
   NumberDaysExpiration: 7
   # -1 to ignore purge else specific a number of days to purge database every n days
   PurgeInterval: 30
+  # Define if the player can create auctions with an item damaged
+  AcceptDamagedItems: true
 WorldAllowed:
   - world
   - world_the_end

--- a/src/main/resources/config - 1.12.yml
+++ b/src/main/resources/config - 1.12.yml
@@ -65,6 +65,16 @@ Price:
     - minecraft:coal
     - minecraft:redstone
     - minecraft:dye/4
+# Items that can't be sold
+ItemsBlacklist:
+  - minecraft:barrier
+  - minecraft:chain_command_block
+  - minecraft:command_block
+  - minecraft:command_block_minecart
+  - minecraft:knowledge_book
+  - minecraft:repeating_command_block
+  - minecraft:structure_block
+  - minecraft:structure_void
 Interfaces:
   Warn: minecraft:stained_glass_pane/14
   Buttons:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -38,7 +38,7 @@ Options:
   # -1 to ignore purge else specific a number of days to purge database every n days
   PurgeInterval: 30
   # Define if the player can create auctions with an item damaged
-  AcceptDamagedItems: true
+  AcceptDamagedItems: false
 Logs:
   HidePrefix: false
 WorldAllowed:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -67,6 +67,17 @@ Price:
     - minecraft:coal
     - minecraft:redstone
     - minecraft:lapis_lazuli
+# Items that can't be sold
+ItemsBlacklist:
+  - minecraft:barrier
+  - minecraft:chain_command_block
+  - minecraft:command_block
+  - minecraft:command_block_minecart
+  - minecraft:debug_stick
+  - minecraft:knowledge_book
+  - minecraft:repeating_command_block
+  - minecraft:structure_block
+  - minecraft:structure_void
 Interfaces:
   Warn: minecraft:red_stained_glass_pane
   Buttons:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -37,6 +37,8 @@ Options:
   NumberDaysExpiration: 7
   # -1 to ignore purge else specific a number of days to purge database every n days
   PurgeInterval: 30
+  # Define if the player can create auctions with an item damaged
+  AcceptDamagedItems: true
 Logs:
   HidePrefix: false
 WorldAllowed:

--- a/src/main/resources/lang-en_EN.yml
+++ b/src/main/resources/lang-en_EN.yml
@@ -165,6 +165,7 @@ ErrorMessages:
   UnknownShop: "&cUnknown Shop : "
   CantRemoveBlock: "&cYou can't remove this block because a shop is attached to it"
   DamagedItem: "You can't sell a damaged item"
+  BlacklistedItem: "You can't sell a blacklisted item"
 InfoMessages:
   UndoAuction: "&2Auction successfully deleted"
   RenewAuction: "&2Auction successfully renewed"

--- a/src/main/resources/lang-en_EN.yml
+++ b/src/main/resources/lang-en_EN.yml
@@ -164,6 +164,7 @@ ErrorMessages:
   PlayerOnly: "&cThis command can only be executed by a player"
   UnknownShop: "&cUnknown Shop : "
   CantRemoveBlock: "&cYou can't remove this block because a shop is attached to it"
+  DamagedItem: "You can't sell a damaged item"
 InfoMessages:
   UndoAuction: "&2Auction successfully deleted"
   RenewAuction: "&2Auction successfully renewed"

--- a/src/main/resources/lang-fr_FR.yml
+++ b/src/main/resources/lang-fr_FR.yml
@@ -165,6 +165,7 @@ ErrorMessages:
   PlayerOnly: "&cCette commande peut uniquement être exécutée par un joueur"
   UnknownShop: "&cShop inconnu : "
   CantRemoveBlock: "&cVous ne pouvez pas supprimer ce bloc car un shop y est rattaché"
+  DamagedItem: "Vous ne pouvez pas vendre un item endommagé"
 InfoMessages:
   UndoAuction: "&2Enchère supprimé avec succès"
   RenewAuction: "&2Enchère renouvelé avec succès"

--- a/src/main/resources/lang-fr_FR.yml
+++ b/src/main/resources/lang-fr_FR.yml
@@ -166,6 +166,7 @@ ErrorMessages:
   UnknownShop: "&cShop inconnu : "
   CantRemoveBlock: "&cVous ne pouvez pas supprimer ce bloc car un shop y est rattaché"
   DamagedItem: "Vous ne pouvez pas vendre un item endommagé"
+  BlacklistedItem: "Vous ne pouvez pas vendre un item blacklisté"
 InfoMessages:
   UndoAuction: "&2Enchère supprimé avec succès"
   RenewAuction: "&2Enchère renouvelé avec succès"


### PR DESCRIPTION
- Fixed WorldUtils that could crash when config variable `WorldAllowed` was not set
- Add flag to accept damaged items to sale (default: false)
- Add items blacklist to prohibit sale of unwanted items

Set by default with these values :
```YAML
ItemsBlacklist:
  - minecraft:barrier
  - minecraft:chain_command_block
  - minecraft:command_block
  - minecraft:command_block_minecart
  - minecraft:debug_stick
  - minecraft:knowledge_book
  - minecraft:repeating_command_block
  - minecraft:structure_block
  - minecraft:structure_void
```