### PR TITLE
Fix group by and default value ended

### DIFF
--- a/src/main/java/fr/epicanard/globalmarketchest/auctions/AuctionInfo.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/auctions/AuctionInfo.java
@@ -2,11 +2,9 @@ package fr.epicanard.globalmarketchest.auctions;
 
 import java.math.BigDecimal;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -50,22 +48,22 @@ public class AuctionInfo {
   public AuctionInfo(ResultSet res) {
     if (res == null)
       throw new NullPointerException("Fail to get auction from database");
-    try {
-      this.id = res.getInt("id");
-      this.itemStack = res.getString("itemStack");
-      this.itemMeta = res.getString("itemMeta");
-      this.amount = res.getInt("amount");
-      this.price = res.getDouble("price");
-      this.ended = res.getBoolean("ended");
-      this.type = AuctionType.getAuctionType(res.getInt("type"));
-      this.playerStarter = res.getString("playerStarter");
-      this.playerEnder = res.getString("playerEnder");
-      this.start = res.getTimestamp("start");
-      this.end = res.getTimestamp("end");
-      this.group = res.getString("group");
-      this.state = StateAuction.getStateAuction(this);
-    } catch (SQLException e) {
-      GlobalMarketChest.plugin.getLogger().log(Level.WARNING, e.getMessage());
+    this.id = DatabaseUtils.getField("id", res::getInt);
+    this.itemStack =  DatabaseUtils.getField("itemStack", res::getString);
+    this.itemMeta =  DatabaseUtils.getField("itemMeta", res::getString);
+    this.amount = DatabaseUtils.getField("amount", res::getInt);
+    this.price = DatabaseUtils.getField("price", res::getDouble);
+    this.ended = DatabaseUtils.getField("ended", res::getBoolean);
+    this.type = AuctionType.getAuctionType(DatabaseUtils.getField("type", res::getInt));
+    this.playerStarter =  DatabaseUtils.getField("playerStarter", res::getString);
+    this.playerEnder =  DatabaseUtils.getField("playerEnder", res::getString);
+    this.start =  DatabaseUtils.getField("start", res::getTimestamp);
+    this.end =  DatabaseUtils.getField("end", res::getTimestamp);
+    this.group =  DatabaseUtils.getField("group", res::getString);
+    this.state = StateAuction.getStateAuction(this);
+
+    if (this.itemMeta == null && this.itemStack != null) {
+      this.itemMeta = DatabaseUtils.serialize(ItemStackUtils.getItemStack(this.itemStack));
     }
   }
 

--- a/src/main/java/fr/epicanard/globalmarketchest/auctions/AuctionType.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/auctions/AuctionType.java
@@ -14,10 +14,18 @@ public enum AuctionType {
     this.type = type;
   }
 
-  public static final AuctionType getAuctionType(int value) {
-    for (AuctionType type : AuctionType.values()) {
-      if (type.getType() == value)
-        return type;
+  /**
+   * Get an Auction Type with is value
+   * 
+   * @param value Value of AuctionType
+   * @return Auction matching value
+   */
+  public static final AuctionType getAuctionType(Integer value) {
+    if (value != null) {
+      for (AuctionType type : AuctionType.values()) {
+        if (type.getType() == value)
+          return type;
+      }
     }
     return AuctionType.SELL;
   }

--- a/src/main/java/fr/epicanard/globalmarketchest/auctions/StateAuction.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/auctions/StateAuction.java
@@ -35,6 +35,8 @@ public enum StateAuction {
    * @return StateAuction
    */
   public static final StateAuction getStateAuction(AuctionInfo auction) {
+    if (auction.getEnded() == null)
+      return StateAuction.INPROGRESS;    
     if (auction.getEnded() == false && auction.getEnd().getTime() < DatabaseUtils.getTimestamp().getTime())
       return StateAuction.EXPIRED;
     if (auction.getEnded() == false)

--- a/src/main/java/fr/epicanard/globalmarketchest/database/ThrowableFunction.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/database/ThrowableFunction.java
@@ -1,0 +1,15 @@
+package fr.epicanard.globalmarketchest.database;
+
+@FunctionalInterface
+public interface ThrowableFunction<T, R, E extends Throwable> {
+
+  /**
+   * Function that take in parameter the type T return R
+   * and can throw exception E
+   * 
+   * @param t Function parameter
+   * @return Return type R
+   * @throws E Can throw exception type E
+   */
+  R apply(T t) throws E;
+}

--- a/src/main/java/fr/epicanard/globalmarketchest/database/connections/MySQLConnection.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/database/connections/MySQLConnection.java
@@ -49,7 +49,7 @@ public class MySQLConnection extends DatabaseConnection {
         "  `playerStarter` TEXT NOT NULL," +
         "  `playerEnder` TEXT DEFAULT NULL," +
         "  `start` TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL," +
-        "  `end` TIMESTAMP NOT NULL," +
+        "  `end` TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL," +
         "  `group` VARCHAR(50) NOT NULL" +
         ");"
       );

--- a/src/main/java/fr/epicanard/globalmarketchest/managers/AuctionManager.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/managers/AuctionManager.java
@@ -215,7 +215,6 @@ public class AuctionManager {
 
     builder.addCondition("group", group);
     this.defineStateCondition(builder, StateAuction.INPROGRESS);
-    builder.addField("*");
     try {
       level.configBuilder(builder, category, item);
     } catch (EmptyCategoryException e) {

--- a/src/main/java/fr/epicanard/globalmarketchest/managers/GroupLevels.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/managers/GroupLevels.java
@@ -89,16 +89,19 @@ public enum GroupLevels {
     builder.addCondition("itemStack", Arrays.asList(items), (category.equals("!")) ? ConditionType.NOTIN : ConditionType.IN);
     switch (groupLevels) {
       case 3:
+        builder.addField("itemStack");
         builder.addField("COUNT(itemStack) AS count");
         builder.setExtension("GROUP BY itemStack");
         break;
       case 2:
+        builder.addField("itemMeta");
         builder.addField("COUNT(itemMeta) AS count");
         builder.setExtension("GROUP BY itemMeta");
         break;
       case 1:
         builder.setExtension("ORDER BY price ASC, start ASC");
-        break;
+      default:
+        builder.addField("*");
     }
   }
 
@@ -116,13 +119,15 @@ public enum GroupLevels {
     switch (groupLevels) {
       case 3:
         builder.addCondition("itemStack", ItemStackUtils.getMinecraftKey(match));
+        builder.addField("itemMeta");
         builder.addField("COUNT(itemMeta) AS count");
         builder.setExtension("GROUP BY itemMeta");
         break;
       case 2:
         builder.addCondition("itemMeta", DatabaseUtils.serialize(match));
         builder.setExtension("ORDER BY price ASC, start ASC");
-        break;
+      default:
+        builder.addField("*");
     }
   }
 
@@ -141,7 +146,8 @@ public enum GroupLevels {
       case 3:
         builder.addCondition("itemMeta", DatabaseUtils.serialize(match));
         builder.setExtension("ORDER BY price ASC, start ASC");
-        break;
+      default:
+        builder.addField("*");
     }
   }
 

--- a/src/main/java/fr/epicanard/globalmarketchest/utils/DatabaseUtils.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/utils/DatabaseUtils.java
@@ -13,6 +13,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.ItemStack;
 
 import fr.epicanard.globalmarketchest.auctions.AuctionInfo;
+import fr.epicanard.globalmarketchest.database.ThrowableFunction;
 import lombok.experimental.UtilityClass;
 
 /**
@@ -169,6 +170,22 @@ public class DatabaseUtils {
       yaml.loadFromString(content);
       return yaml.getItemStack("item");
     } catch (InvalidConfigurationException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Get a field inside a ResultSet or return null if not exist
+   * 
+   * @param <T> Return type of callback
+   * @param field Field name to get
+   * @param callback Callback that get the field
+   * @return
+   */
+  public <T> T getField(String field, ThrowableFunction<String, T, SQLException> callback) {
+    try {
+      return callback.apply(field);
+    } catch (SQLException e) {
       return null;
     }
   }


### PR DESCRIPTION
This issue was caused by mysql parameter `sql_mode=ONLY_FULL_GROUP_BY` by default activate on new versions of mysql 5.7+.

Fix :
- Fix sql request to match required sql_mode
- Add default value for timestamp `ended` of table `GMC_auctions`