### PR TITLE
Add server tax functionality. 

### DIFF
--- a/src/main/java/fr/epicanard/globalmarketchest/GlobalMarketChest.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/GlobalMarketChest.java
@@ -1,5 +1,8 @@
 package fr.epicanard.globalmarketchest;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import fr.epicanard.globalmarketchest.commands.CommandHandler;
 import fr.epicanard.globalmarketchest.configuration.ConfigLoader;
 import fr.epicanard.globalmarketchest.configuration.PriceLimit;
@@ -29,8 +32,10 @@ import org.bukkit.event.Listener;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.net.URL;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Scanner;
 import java.util.logging.Level;
 
 
@@ -226,7 +231,7 @@ public class GlobalMarketChest extends JavaPlugin {
    * @param sender Player to send the message
    */
   public static void checkNewVersion(final CommandSender sender) {
-    /*try (Scanner s = new Scanner(new URL("https://api.spiget.org/v2/resources/64921/versions/latest").openStream())) {
+    try (Scanner s = new Scanner(new URL("https://api.spiget.org/v2/resources/64921/versions/latest").openStream())) {
       final String value = s.useDelimiter("\\A").next();
       final JsonObject obj = (JsonObject) new JsonParser().parse(value);
       final String lastVersion = obj.get("name").getAsString();
@@ -240,6 +245,5 @@ public class GlobalMarketChest extends JavaPlugin {
     } catch (Exception e) {
       System.out.println(e.getMessage());
     }
-    */
   }
 }

--- a/src/main/java/fr/epicanard/globalmarketchest/GlobalMarketChest.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/GlobalMarketChest.java
@@ -19,13 +19,8 @@ import fr.epicanard.globalmarketchest.listeners.*;
 import fr.epicanard.globalmarketchest.managers.AuctionManager;
 import fr.epicanard.globalmarketchest.managers.ShopManager;
 import fr.epicanard.globalmarketchest.ranks.RanksLoader;
-import fr.epicanard.globalmarketchest.utils.ConfigUtils;
-import fr.epicanard.globalmarketchest.utils.LangUtils;
-import fr.epicanard.globalmarketchest.utils.LoggerUtils;
-import fr.epicanard.globalmarketchest.utils.PlayerUtils;
-import fr.epicanard.globalmarketchest.utils.ShopUtils;
+import fr.epicanard.globalmarketchest.utils.*;
 import lombok.Getter;
-
 import org.bstats.bukkit.Metrics;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -34,15 +29,9 @@ import org.bukkit.event.Listener;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.net.URL;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Scanner;
 import java.util.logging.Level;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 
 public class GlobalMarketChest extends JavaPlugin {
@@ -237,7 +226,7 @@ public class GlobalMarketChest extends JavaPlugin {
    * @param sender Player to send the message
    */
   public static void checkNewVersion(final CommandSender sender) {
-    try (Scanner s = new Scanner(new URL("https://api.spiget.org/v2/resources/64921/versions/latest").openStream())) {
+    /*try (Scanner s = new Scanner(new URL("https://api.spiget.org/v2/resources/64921/versions/latest").openStream())) {
       final String value = s.useDelimiter("\\A").next();
       final JsonObject obj = (JsonObject) new JsonParser().parse(value);
       final String lastVersion = obj.get("name").getAsString();
@@ -251,5 +240,6 @@ public class GlobalMarketChest extends JavaPlugin {
     } catch (Exception e) {
       System.out.println(e.getMessage());
     }
+    */
   }
 }

--- a/src/main/java/fr/epicanard/globalmarketchest/auctions/AuctionInfo.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/auctions/AuctionInfo.java
@@ -86,17 +86,12 @@ public class AuctionInfo {
   }
 
   /**
-   * Get final total price of auction after tax
+   * Get final total price of auction the seller will receive after tax deduction
    *
    * @return Final total price after tax
    */
   public Double getTaxedPrice() {
-    //Check if the tax is a valid multiplier or bad things may happen if configured outside the proper bounds
-    double taxMultiplier = 1 - ConfigUtils.getDouble("Options.ServerTax", 0);
-    if (taxMultiplier < 0 || taxMultiplier > 1) {
-      taxMultiplier = 0.0;
-    }
-    return BigDecimal.valueOf(getTotalPrice()).multiply(BigDecimal.valueOf(taxMultiplier)).doubleValue();
+    return BigDecimal.valueOf(getTotalPrice()).subtract(BigDecimal.valueOf(getTaxAmount())).doubleValue();
   }
 
   /**

--- a/src/main/java/fr/epicanard/globalmarketchest/auctions/AuctionInfo.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/auctions/AuctionInfo.java
@@ -86,6 +86,34 @@ public class AuctionInfo {
   }
 
   /**
+   * Get final total price of auction after tax
+   *
+   * @return Final total price after tax
+   */
+  public Double getTaxedPrice() {
+    //Check if the tax is a valid multiplier or bad things may happen if configured outside the proper bounds
+    double taxMultiplier = 1 - ConfigUtils.getDouble("Options.ServerTax", 0);
+    if (taxMultiplier < 0 || taxMultiplier > 1) {
+      taxMultiplier = 0.0;
+    }
+    return BigDecimal.valueOf(getTotalPrice()).multiply(BigDecimal.valueOf(taxMultiplier)).doubleValue();
+  }
+
+  /**
+   * Get taxed amount
+   *
+   * @return Total tax amount
+   */
+  public Double getTaxAmount() {
+    //Check if the tax is a valid multiplier or bad things may happen if configured outside the propper bounds
+    double taxMultiplier = ConfigUtils.getDouble("Options.ServerTax", 0);
+    if (taxMultiplier < 0 || taxMultiplier > 1) {
+      taxMultiplier = 0.0;
+    }
+    return BigDecimal.valueOf(getTotalPrice()).multiply(BigDecimal.valueOf(taxMultiplier)).doubleValue();
+  }
+
+  /**
    * Set itemstack inside auction
    *
    * @param item Item to set inside auction

--- a/src/main/java/fr/epicanard/globalmarketchest/economy/VaultEconomy.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/economy/VaultEconomy.java
@@ -1,18 +1,17 @@
 package fr.epicanard.globalmarketchest.economy;
 
-import java.util.UUID;
-
-import org.bukkit.OfflinePlayer;
-import org.bukkit.Server;
-import org.bukkit.entity.Player;
-import org.bukkit.plugin.RegisteredServiceProvider;
-
 import fr.epicanard.globalmarketchest.GlobalMarketChest;
 import fr.epicanard.globalmarketchest.exceptions.RequiredPluginException;
 import fr.epicanard.globalmarketchest.utils.PlayerUtils;
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.permission.Permission;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.Server;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+import java.util.UUID;
 
 public class VaultEconomy {
   private Economy economy;
@@ -123,8 +122,8 @@ public class VaultEconomy {
     return this.economy.getBalance(player);
   }
 
-  public void exchangeMoney(UUID playerTake, UUID playerGive, Double price) {
+  public void exchangeMoney(UUID playerTake, UUID playerGive, Double price, Double priceAfterTax) {
     this.takeMoneyToPlayer(playerTake, price);
-    this.giveMoneyToPlayer(playerGive, price);
+    this.giveMoneyToPlayer(playerGive, priceAfterTax);
   }
 }

--- a/src/main/java/fr/epicanard/globalmarketchest/gui/shops/interfaces/BuyAuction.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/gui/shops/interfaces/BuyAuction.java
@@ -87,7 +87,7 @@ public class BuyAuction extends UndoAuction {
       if (!GlobalMarketChest.plugin.auctionManager.buyAuction(auction.getId(), i.getPlayer()))
         throw new WarnException("CantBuyAuction");
 
-      final MoneyExchangeEvent event = new MoneyExchangeEvent(i.getPlayer().getUniqueId(), playerStarter, auction.getTotalPrice());
+      final MoneyExchangeEvent event = new MoneyExchangeEvent(i.getPlayer().getUniqueId(), playerStarter, auction.getTotalPrice(), auction.getTaxedPrice());
       Bukkit.getServer().getPluginManager().callEvent(event);
 
       i.getPlayer().getInventory().addItem(ItemStackUtils.splitStack(item, auction.getAmount()));
@@ -110,13 +110,15 @@ public class BuyAuction extends UndoAuction {
    */
   private String formatMessage(Boolean isOwner, AuctionInfo auction, Player buyer, ItemStack item) {
     final String langVariable = (isOwner) ? "InfoMessages.AcquireAuctionOwner" : "InfoMessages.AcquireAuction";
-    final Map<String, Object> mapping = ImmutableMap.of(
-        "buyer", ConfigUtils.getBoolean("Options.Anonymous.Buyer", false) ? LangUtils.getOrElse("Divers.Anonymous", "Anonymous") : buyer.getName(),
-        "quantity", auction.getAmount(),
-        "itemName", ItemStackUtils.getItemStackDisplayName(item),
-        "price", EconomyUtils.format(auction.getTotalPrice()),
-        "seller", ConfigUtils.getBoolean("Options.Anonymous.Seller", false) ? LangUtils.getOrElse("Divers.Anonymous", "Anonymous") : PlayerUtils.getPlayerName(auction.getPlayerStarter())
-    );
+    final Map<String, Object> mapping = ImmutableMap.<String, Object>builder()
+            .put("buyer", ConfigUtils.getBoolean("Options.Anonymous.Buyer", false) ? LangUtils.getOrElse("Divers.Anonymous", "Anonymous") : buyer.getName())
+            .put("quantity", auction.getAmount())
+            .put("itemName", ItemStackUtils.getItemStackDisplayName(item))
+            .put("price", EconomyUtils.format(auction.getTotalPrice()))
+            .put("finalPrice", EconomyUtils.format(auction.getTaxedPrice()))
+            .put("seller", ConfigUtils.getBoolean("Options.Anonymous.Seller", false) ? LangUtils.getOrElse("Divers.Anonymous", "Anonymous") : PlayerUtils.getPlayerName(auction.getPlayerStarter()))
+            .put("tax", auction.getTaxAmount())
+            .build();
 
     return LangUtils.format(langVariable, mapping);
   }

--- a/src/main/java/fr/epicanard/globalmarketchest/listeners/MoneyExchangeListener.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/listeners/MoneyExchangeListener.java
@@ -9,6 +9,6 @@ public class MoneyExchangeListener implements Listener {
 
   @EventHandler
   public void onMoneyExchange(final MoneyExchangeEvent event) {
-    GlobalMarketChest.plugin.economy.exchangeMoney(event.getSourcePlayer(), event.getTargetPlayer(), event.getPrice());
+    GlobalMarketChest.plugin.economy.exchangeMoney(event.getSourcePlayer(), event.getTargetPlayer(), event.getPrice(), event.getPriceAfterTax());
   }
 }

--- a/src/main/java/fr/epicanard/globalmarketchest/listeners/events/MoneyExchangeEvent.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/listeners/events/MoneyExchangeEvent.java
@@ -17,6 +17,8 @@ public class MoneyExchangeEvent extends Event {
   private UUID targetPlayer;
   @Getter
   private Double price;
+  @Getter
+  private Double priceAfterTax;
 
   @Override
   public HandlerList getHandlers() {

--- a/src/main/java/fr/epicanard/globalmarketchest/utils/ConfigUtils.java
+++ b/src/main/java/fr/epicanard/globalmarketchest/utils/ConfigUtils.java
@@ -50,4 +50,5 @@ public class ConfigUtils {
   public List<String> getStringList(final String path) {
     return GlobalMarketChest.plugin.getConfigLoader().getConfig().getStringList(path);
   }
+
 }

--- a/src/main/resources/1.17/config.yml
+++ b/src/main/resources/1.17/config.yml
@@ -78,6 +78,8 @@ Options:
     Analyze: "all"
     # Define the number of days to analyze for average of advice price on choice price view
     Days: 30
+  # Server tax (decimal, between 0 and 1) to be withheld after someone makes a purchase. Use 0.0 to disable.
+  ServerTax: 0.2
   # Config about shulker box
   ShulkerBox:
     # Allow to see the content of a shulker box when a player want to buy it

--- a/src/main/resources/langs/lang-en_US.yml
+++ b/src/main/resources/langs/lang-en_US.yml
@@ -236,7 +236,7 @@ InfoMessages:
   UndoEveryAuction: "&2Every auction successfully deleted"
   ShopDeleted: "Shop successfully deleted"
   AcquireAuction: "&3{buyer} &6bought &2{quantity} {itemName} &6for &2{price}&6 to &3{seller}&6."
-  AcquireAuctionOwner: "&3{buyer} &6bought your auction &2{quantity} {itemName} &6for &2{price}&6."
+  AcquireAuctionOwner: "&3{buyer} &6bought your auction &2{quantity} {itemName} &6for &2{finalPrice} ({price} - {tax} in taxes)&6."
   AuctionCreated: "&3{seller} &6created &3{auctionNumber}&6 auctions of &2{quantity} {itemName} &6for &2{price}&6."
   LoginMessage:
     BaseMessage: "&6Since your last connection :"


### PR DESCRIPTION
Hello, since I needed this, I added a server tax functionality. I decided to share my changes just in case you need them someday - you don't have to accept the PR. I tried to follow your coding style but it's not exactly the same :D

The server tax can be defined in the config as a double between 0 and 1 and it represents what % of the price should be taken from the server before paying the seller.